### PR TITLE
feat: modal wrapper

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,23 +1,17 @@
-import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+"use client"
 
-import { Button } from "@/components/ui/button";
+import React from "react";
+import { useModalStore } from "@/hooks/use-modal-store";
 
 export default function Home() {
-  return (
-    <main className="flex flex-col items-center justify-between min-h-screen p-24">
-      <div className="px-5 py-2 border-2 rounded-lg border-border bg-muted">
-        <div className="flex items-center gap-x-4">
-          <h1 className="text-lg font-medium">Welcome to PeakBuy</h1>
-          <SignedIn>
-            <UserButton afterSignOutUrl="/" />
-          </SignedIn>
-          <SignedOut>
-            <SignInButton>
-              <Button variant='default' size='sm'>Sign in</Button>
-            </SignInButton>
-          </SignedOut>
-        </div>
-      </div>
-    </main>
-  );
+  const onOpen = useModalStore((state) => state.onOpen);
+  const isOpen = useModalStore((state) => state.isOpen);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      onOpen();
+    }
+  }, [isOpen, onOpen]);
+  
+  return null;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/styles/globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Inter } from "next/font/google";
 import type { Metadata } from "next";
+import Providers from "@/providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,7 +20,9 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en">
-        <body className={inter.className}>{children}</body>
+        <body className={inter.className}>
+          <Providers>{children}</Providers>
+        </body>
       </html>
     </ClerkProvider>
   );

--- a/components/others/create-store-modal.tsx
+++ b/components/others/create-store-modal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/shared/modal";
+import { useForm } from "react-hook-form";
+import { useModalStore } from "@/hooks/use-modal-store";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const createStoreSchema = z.object({
+  name: z
+    .string()
+    .min(2, {
+      message: "Must be at least 2 or more characters",
+    })
+    .max(25, { message: "Must be at most 25 or less characters" }),
+});
+
+type CreateStoreSchema = z.infer<typeof createStoreSchema>;
+
+export function CreateStoreModal() {
+  const _create_store_modal = useModalStore();
+
+  const form = useForm<CreateStoreSchema>({
+    resolver: zodResolver(createStoreSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  async function onSubmit(values: CreateStoreSchema) {
+    console.log(values);
+  }
+
+  return (
+    <Modal
+      title="Create a Store"
+      description="Add a new store to manage Products, Categories, Sales, and More."
+      isOpen={_create_store_modal.isOpen}
+      onClose={_create_store_modal.onClose}
+    >
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Store Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="ex. johndoe's sticker packs" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex items-center justify-end gap-x-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={_create_store_modal.onClose}
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Create</Button>
+          </div>
+        </form>
+      </Form>
+    </Modal>
+  );
+}

--- a/components/shared/modal.tsx
+++ b/components/shared/modal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import React from "react";
+
+type ModalProps = {
+  title: string;
+  description: string;
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export function Modal({
+  title,
+  description,
+  isOpen,
+  children,
+  onClose,
+}: ModalProps) {
+  function onChange(open: boolean): void {
+    if (!open) {
+      onClose();
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onChange}>
+      <DialogContent className="sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <React.Fragment>{children}</React.Fragment>
+        <DialogFooter className="pt-4 border-t border-border">
+          <p className="typo-muted">
+            &copy; 2024 PeakBuy
+            <span className="font-bold">Admin</span>
+          </p>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hooks/use-modal-store.ts
+++ b/hooks/use-modal-store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type ModalStore = {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+const useModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  onOpen: () => set({ isOpen: true }),
+  onClose: () => set({ isOpen: false }),
+}));
+
+export { useModalStore };

--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+function useMounted() {
+  const [isMounted, setIsMounted] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return {
+    isMounted,
+  };
+}
+
+export { useMounted };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.0",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zustand": "^4.5.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -6690,6 +6691,33 @@
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.0.tgz",
+      "integrity": "sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -1,0 +1,15 @@
+import { ModalProvider } from "./modal-provider";
+import React from "react";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function Providers({ children }: Props) {
+  return (
+    <React.Fragment>
+      {children}
+      <ModalProvider />
+    </React.Fragment>
+  );
+}

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { CreateStoreModal } from "@/components/others/create-store-modal";
+import { useMounted } from "@/hooks/use-mounted";
+
+export function ModalProvider() {
+  const { isMounted } = useMounted();
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <>
+      <CreateStoreModal />
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,4 +79,33 @@ body,
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Typography */
+  .typo-h1 {
+    @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
+  }
+  .typo-h2 {
+    @apply scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0;
+  }
+  .typo-h3 {
+    @apply scroll-m-20 text-2xl font-semibold tracking-tight;
+  }
+  .typo-h4 {
+    @apply scroll-m-20 text-xl font-semibold tracking-tight;
+  }
+  .typo-base {
+    @apply leading-7 [&:not(:first-child)]:mt-6;
+  }
+  .typo-xl {
+    @apply text-xl text-muted-foreground;
+  }
+  .typo-lg {
+    @apply text-lg font-semibold;
+  }
+  .typo-sm {
+    @apply text-sm font-medium leading-none;
+  }
+  .typo-muted {
+    @apply text-sm text-muted-foreground;
+  }
 }


### PR DESCRIPTION
- Added a modal wrapper using Zustand to allow the creation of different modals with the application.
- `Create Store modal` is used to create an initial store from the admin portal if the user is a new user.
- Updated the globals.css file to include general styling for typography
- Added providers for managing the state of the Zustand store and a Single source of truth for the modals